### PR TITLE
Translate from German to English.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
-Redmine Wikiapproval Macro Plugin
-==================================
+# Redmine Wikiapproval Macro Plugin
 
 This plugin provides a macro for marking revisions of wiki pages as approved and displaying the approval status.
 
-Requirements
-------------
+## Requirements
 
 Redmine 3.0.x, 3.1.x, 4.0.x or 4.1.x
 Other versions are not tested but may work.
 
-Installation
-------------
+## Installation
+
 1. Download archive and extract to /your/path/to/redmine/plugins/
 2. Restart Redmine
 
 Login to Redmine and go to Administration->Plugins. You should now see 'Redmine Wikiapproval'. Enjoy!
 
-Usage
-------------
+## Usage
+
 Anywhere, ideally on top, on a wiki page include the macro {{approvepage}} to display the approved state of the page or page revision.
 
-When saving changes to a wiki page add a comment text starting with the word "Freigegeben:" to the comment to approve a page.
+When saving changes to a wiki page add a comment text starting with the word "Approved:" to the comment to approve a page.

--- a/init.rb
+++ b/init.rb
@@ -47,9 +47,9 @@ DESCRIPTION
 			#out << page.versions[page.versions.size-3].version.to_s
 
 			if page.versions.last.comments.starts_with?('Freigegeben:')
-				out <<content_tag(:p, safe_join(["Approval Status: ", content_tag(:span, "Approved", :style=>"color:green"), " by ", link_to_user(obj.author), " ", time_tag(page.updated_on), "ago. " ]))
+				out <<content_tag(:p, safe_join(["Approval Status: ", content_tag(:span, "Approved", :style=>"color:green"), " by ", link_to_user(obj.author), " ", time_tag(page.updated_on), " ago. " ]))
 			else
-				out <<content_tag(:p, safe_join(["Approval Status: ", content_tag(:span, "Not Approved.", :style=>"color:red"), " Last changed by ", link_to_user(obj.author), " ", time_tag(page.updated_on), "ago. " ]))
+				out <<content_tag(:p, safe_join(["Approval Status: ", content_tag(:span, "Not Approved.", :style=>"color:red"), " Last changed by ", link_to_user(obj.author), " ", time_tag(page.updated_on), " ago. " ]))
 
 				for i in (page.versions.size-1).downto(0)
 					#out << content_tag(:p, page.versions[i].version.to_s+", "+page.versions[i].comments)
@@ -66,13 +66,13 @@ DESCRIPTION
                                         out << link_to_user(page.versions[lastapprovedindex].author)
                                         out << " ".html_safe
                                         out << time_tag(page.versions[lastapprovedindex].updated_on)
-                                        out << "ago. ".html_safe
+                                        out << " ago. ".html_safe
                                         #https://github.com/redmine/redmine/blob/master/app/views/wiki/history.html.erb
                                         #out << link_to(page.page.version, :action => 'show', :id=>page.page.title, :project_id => page.page.project, :version => page.page.v
 
                                         #link_to ver.version, :action => 'show', :id => @page.title, :project_id => @page.project, :version => ver.version
                                 else
-                                        out << content_tag(:p, "Es gibt noch keine freigegebene Revision. Diese Seite darf nicht produktiv verwendet werden!", :style=>"color:red")
+                                        out << content_tag(:p, "There is no approved revision yet. This page may not be used productively!", :style=>"color:red")
                                 end
 			end
 			#out << content_tag(:span,safe_join([avatar(obj.author, size: 14), ' ', link_to_user(obj.author)]),class: 'last-updated-by')
@@ -110,20 +110,20 @@ DESCRIPTION
 
                                if obj.comments.starts_with?('Freigegeben:')
                                        if (obj.version - 1 ) == lastapprovedindex
-                                               out << content_tag(:p, "Dies ist die neuste freigegebene Revision.", :style=>"color:green")
+                                               out << content_tag(:p, "This is the latest approved Revision.", :style=>"color:green")
                                        else
-                                               out << content_tag(:p, safe_join(["Dies ist eine veraltete freigegebene Revision! Die neuste freigegebene Revision ist ", link_to('Revision '+obj.page.content.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>obj.page.title, :project_id => obj.page.content.project, :version => obj.page.content.versions[lastapprovedindex].version.to_s)]), :style=>"color:red")
-                                               out << content_tag(:p, safe_join(["Für produktive Arbeiten unbedingt die letzte freigegebene Revision verwenden! Dazu hier klicken: ", link_to('Revision '+obj.page.content.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>obj.page.title, :project_id => obj.page.content.project, :version => obj.page.content.versions[lastapprovedindex].version.to_s), ". " ]), :style=>"color:red")
+                                               out << content_tag(:p, safe_join(["This is an outdated approved revision! The latest approved revision is ", link_to('Revision '+obj.page.content.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>obj.page.title, :project_id => obj.page.content.project, :version => obj.page.content.versions[lastapprovedindex].version.to_s)]), :style=>"color:red")
+                                               out << content_tag(:p, safe_join(["For productive work, be sure to use the latest approved revision! To do so, click here: ", link_to('Revision '+obj.page.content.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>obj.page.title, :project_id => obj.page.content.project, :version => obj.page.content.versions[lastapprovedindex].version.to_s), ". " ]), :style=>"color:red")
                                                #out << content_tag(:p, "Dies ist eine veraltete freigegebene Revision!  Die neuste freigegebene Revision ist ", :style=>"color:red")
                                                #out << link_to('Revision '+obj.page.content.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>obj.page.title, :project_id => obj.page.content.project, :version => obj.page.content.versions[lastapprovedindex].version.to_s)
                                        end
                                else
                                        if lastapprovedindex != ""
-                                               out << content_tag(:p, safe_join(["Diese Revision ist nicht freigegeben! Die neuste freigegebene Revision ist ", link_to('Revision '+obj.page.content.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>obj.page.title, :project_id => obj.page.content.project, :version => obj.page.content.versions[lastapprovedindex].version.to_s)]), :style=>"color:red")
-                                               out << content_tag(:p, safe_join(["Für produktive Arbeiten unbedingt die letzte freigegebene Revision verwenden! Dazu hier klicken: ", link_to('Revision '+obj.page.content.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>obj.page.title, :project_id => obj.page.content.project, :version => obj.page.content.versions[lastapprovedindex].version.to_s), ". " ]), :style=>"color:red")
+                                               out << content_tag(:p, safe_join(["This revision is not approved! The latest approved revision is ", link_to('Revision '+obj.page.content.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>obj.page.title, :project_id => obj.page.content.project, :version => obj.page.content.versions[lastapprovedindex].version.to_s)]), :style=>"color:red")
+                                               out << content_tag(:p, safe_join(["For productive work, be sure to use the latest approved revision! To do so, click here: ", link_to('Revision '+obj.page.content.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>obj.page.title, :project_id => obj.page.content.project, :version => obj.page.content.versions[lastapprovedindex].version.to_s), ". " ]), :style=>"color:red")
                                                 #out << link_to('Revision '+obj.page.content.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>obj.page.title, :project_id => obj.page.content.project, :version => obj.page.content.versions[lastapprovedindex].version.to_s)
                                        else
-                                               out << content_tag(:p, "Diese Revision ist nicht freigegeben! Es gibt noch keine freigegebene Revision. Diese Seite darf nicht produktiv verwendet werden!", :style=>"color:red")
+                                               out << content_tag(:p, "This revision is not approved! There is no approved revision yet.", :style=>"color:red")
                                        end
                                end
 

--- a/init.rb
+++ b/init.rb
@@ -46,14 +46,14 @@ DESCRIPTION
 			#out << page.versions.last.updated_on.to_s
 			#out << page.versions[page.versions.size-3].version.to_s
 
-			if page.versions.last.comments.starts_with?('Freigegeben:')
+			if page.versions.last.comments.starts_with?('Freigegeben:') || page.versions.last.comments.starts_with?('Approved:')
 				out <<content_tag(:p, safe_join(["Approval Status: ", content_tag(:span, "Approved", :style=>"color:green"), " by ", link_to_user(obj.author), " ", time_tag(page.updated_on), " ago. " ]))
 			else
 				out <<content_tag(:p, safe_join(["Approval Status: ", content_tag(:span, "Not Approved.", :style=>"color:red"), " Last changed by ", link_to_user(obj.author), " ", time_tag(page.updated_on), " ago. " ]))
 
 				for i in (page.versions.size-1).downto(0)
 					#out << content_tag(:p, page.versions[i].version.to_s+", "+page.versions[i].comments)
-					if page.versions[i].comments.starts_with?('Freigegeben:')
+					if page.versions[i].comments.starts_with?('Freigegeben:') || page.versions[i].comments.starts_with?('Approved:')
 						#lastapproved=(i+1).to_s
 						lastapprovedindex=i#page.versions[i].version.to_s
 						break
@@ -98,7 +98,7 @@ DESCRIPTION
 
                                for i in (obj.page.content.versions.size-1).downto(0)
                                        #out << content_tag(:p, page.versions[i].version.to_s+", "+page.versions[i].comments)
-                                       if obj.page.content.versions[i].comments.starts_with?('Freigegeben:')
+                                       if obj.page.content.versions[i].comments.starts_with?('Freigegeben:') || obj.page.content.versions[i].comments.starts_with?('Approved:')
                                                #lastapproved=(i+1).to_s
                                                lastapprovedindex=i#page.versions[i].version.to_s
                                                break
@@ -108,7 +108,7 @@ DESCRIPTION
                                #out << " ÄÄÄÄ lastapprovedindex: " << lastapprovedindex.to_s
                                #out << " obj.version" << obj.version.to_s <<  "ÄÄÄÄ"
 
-                               if obj.comments.starts_with?('Freigegeben:')
+                               if obj.comments.starts_with?('Freigegeben:') || obj.comments.starts_with?('Approved:')
                                        if (obj.version - 1 ) == lastapprovedindex
                                                out << content_tag(:p, "This is the latest approved Revision.", :style=>"color:green")
                                        else

--- a/init.rb
+++ b/init.rb
@@ -47,9 +47,9 @@ DESCRIPTION
 			#out << page.versions[page.versions.size-3].version.to_s
 
 			if page.versions.last.comments.starts_with?('Freigegeben:')
-				out <<content_tag(:p, safe_join(["Status der Arbeitsanweisung: ", content_tag(:span, "Freigegeben", :style=>"color:green"), " von ",link_to_user(obj.author) , " vor ", time_tag(page.updated_on), ". " ]))
+				out <<content_tag(:p, safe_join(["Approval Status: ", content_tag(:span, "Approved", :style=>"color:green"), " by ", link_to_user(obj.author), " ", time_tag(page.updated_on), "ago. " ]))
 			else
-				out <<content_tag(:p, safe_join(["Status der Arbeitsanweisung: ", content_tag(:span, "Nicht freigegeben.", :style=>"color:red"), " Zuletzt geändert von ",link_to_user(obj.author) , " vor ", time_tag(page.updated_on), ". " ]))
+				out <<content_tag(:p, safe_join(["Approval Status: ", content_tag(:span, "Not Approved.", :style=>"color:red"), " Last changed by ", link_to_user(obj.author), " ", time_tag(page.updated_on), "ago. " ]))
 
 				for i in (page.versions.size-1).downto(0)
 					#out << content_tag(:p, page.versions[i].version.to_s+", "+page.versions[i].comments)
@@ -60,14 +60,13 @@ DESCRIPTION
 					end
 				end
 				if lastapprovedindex != ""
-                                        out << "Die letzte freigegebene Revision ist: "
+                                        out << "The last approved revision is: "
                                         out << link_to('Revision '+page.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>page.page.title, :project_id => page.page.project, :version => page.versions[lastapprovedindex].version.to_s)
-                                        out << " von ".html_safe
+                                        out << " by ".html_safe
                                         out << link_to_user(page.versions[lastapprovedindex].author)
-                                        out << " vor ".html_safe
+                                        out << " ".html_safe
                                         out << time_tag(page.versions[lastapprovedindex].updated_on)
-                                        out << ". ".html_safe
-                                        out << content_tag(:p, safe_join(["Für produktive Arbeiten unbedingt die letzte freigegebene Revision verwenden! Dazu hier klicken: ", link_to('Revision '+page.versions[lastapprovedindex].version.to_s, :action => 'show', :id=>page.page.title, :project_id => page.page.project, :version => page.versions[lastapprovedindex].version.to_s), ". " ]), :style=>"color:red")
+                                        out << "ago. ".html_safe
                                         #https://github.com/redmine/redmine/blob/master/app/views/wiki/history.html.erb
                                         #out << link_to(page.page.version, :action => 'show', :id=>page.page.title, :project_id => page.page.project, :version => page.page.v
 


### PR DESCRIPTION
* Translated from German to English. In English, I use "approved" instead of "released".
* In addition to the existing "Freigegeben", "Approved" can also be used for approval.